### PR TITLE
bug fix: ee-find-file opens the file with wrong path

### DIFF
--- a/eee.el
+++ b/eee.el
@@ -1,9 +1,9 @@
 ;;; package --- Summary -*- lexical-binding: t -*-
 ;; eee.el is the meaning of Eval! Exec! Enhance!
-;; 
+;;
 ;; Author Github: https://github.com/eval-exec
 ;; Author Blog:   https://evex.one
-;; 
+;;
 ;; Eval! Exec! Enhance!
 ;; Eval! Exec! Excited!
 ;; Eval! Exec! Enjoy!
@@ -86,13 +86,14 @@ NAME is passed to `ee-start-terminal-function'."
 
 (defun ee-find-file (target-file)
   (message "ee-find-file: %s" target-file)
-  (when (not (string-empty-p target-file))
-    (if (not current-prefix-arg)
-        (find-file (string-trim target-file))
-      (let ((action-fn
-             (alist-get (completing-read "Action:" ee-find-file--actions)
-                        ee-find-file--actions nil nil 'equal)))
-        (funcall action-fn target-file)))))
+  (let* ((default-directory (ee-get-project-dir-or-current-dir)))
+    (when (not (string-empty-p target-file))
+      (if (not current-prefix-arg)
+          (find-file (string-trim target-file))
+        (let ((action-fn
+               (alist-get (completing-read "Action:" ee-find-file--actions)
+                          ee-find-file--actions nil nil 'equal)))
+          (funcall action-fn target-file))))))
 
 (defun ee--normalize-path (path)
   (string-trim-right path (rx (or "\n" "\\" "/"))))


### PR DESCRIPTION
Basically eee.el will call `ee-get-project-dir-or-current-dir` (which returns the root directory for the given repo) before launching the TUI.

When TUI finished and file path returned to Emacs is relative to the root of git repo. However `default-directory` may NOT be the root of git repo (this happens when user run `ee-*` command while visiting a file from a sub-directory of the git repo), in this case, `find-file` will try to visit a file path which does not exist and lead to error.