### PR TITLE
add default ghostty window title "ee-ghostty"

### DIFF
--- a/eee.el
+++ b/eee.el
@@ -24,6 +24,7 @@
 	   "--option=window.decorations=\\\"None\\\" --option=window.dimensions.columns=180 --option=window.dimensions.lines=50")
 	 ("kitty" . "--title ee-kitty")
 	 ("konsole" . "--hide-menubar")
+         ("ghostty" . "--title=ee-ghostty")
 	 )
   "The terminal command options to use for ee-* commands."
   :type 'alist


### PR DESCRIPTION
Hi , I'd love to contribute something. But honestly I am totally no techy person. If the code was wrong (at least it works on my arch linux, emacs 29.4) ,just reject it. XD
I myself didn't modify your source-code, I just add the following line in my configuration:
```
(setq ee-terminal-options '(("ghostty" . "--title=ee-ghostty")))
```
Maybe we could just add this line in README.md so that users could config that as they want.