### PR TITLE
Add a common function check_tools to check the availability of tools

### DIFF
--- a/eee-common.sh
+++ b/eee-common.sh
@@ -18,3 +18,53 @@ f3:execute(${EEE_SYMBOL_SCRIPT} {})\
 # FZF_F2_BIND="f2:become(${EEE_RG_SCRIPT} {})"
 
 logger -t eee.el -- EEE_F1_BIND=${FZF_F1_BIND}
+
+error() {
+    echo "error: $*"
+    exit 1
+} >&2
+
+check_tools() {
+    local tool
+    for tool; do
+        case "$tool" in
+            bat)
+                __lookup_tool BAT bat batcat
+                ;;
+
+            devicon-lookup)
+                __lookup_tool DEVICON_LOOKUP devicon-lookup
+                ;;
+
+            fd)
+                __lookup_tool FD fd fdfind
+                ;;
+
+            fzf)
+                __lookup_tool FZF fzf
+                ;;
+
+            rg)
+                __lookup_tool RG rg
+                ;;
+
+            *)
+                error "unknown tool '$tool'"
+        esac
+    done
+}
+
+__lookup_tool() {
+    local var knownas t p
+    var=$1
+    shift
+    knownas=$1
+    for t; do
+        p="$(command -v $t)" && {
+            eval "$var='$p'"
+            return 0
+        }
+    done
+
+    error "tool '$knownas' not installed"
+}

--- a/eee-find.sh
+++ b/eee-find.sh
@@ -4,10 +4,12 @@ set -Eeuo pipefail
 CURR_DIR=$(dirname $(readlink -f $0))
 . ${CURR_DIR}/eee-common.sh
 
-INITIAL_QUERY="$1"
+INITIAL_QUERY="${1:-}"
 
-fd --type f --type l --hidden --exclude .git --exclude target | devicon-lookup -i -c |
-  fzf \
+check_tools fd devicon-lookup fzf bat
+
+$FD --type f --type l --hidden --exclude .git --exclude target | $DEVICON_LOOKUP -i -c |
+  $FZF \
     --query "$INITIAL_QUERY" \
     --border \
     --layout reverse \
@@ -17,7 +19,7 @@ fd --type f --type l --hidden --exclude .git --exclude target | devicon-lookup -
     --color "border:#A15ABD" \
     --header-first \
     --header "CWD:$(pwd) " \
-    --preview 'filename={}; bat -n --color=always ${filename:2}' \
+    --preview 'filename={}; '"$BAT"' -n --color=always ${filename:2}' \
     --preview-window 'right,60%,border-bottom,wrap,+{2}+3/3,~3' \
     --bind "${FZF_BINDS}" \
     --bind 'ctrl-/:change-preview-window(down|hidden|)' \

--- a/eee-rg.sh
+++ b/eee-rg.sh
@@ -8,6 +8,8 @@ CURR_DIR=$(dirname $(readlink -f $0))
 . ${CURR_DIR}/eee-common.sh
 EE_REGEX=${CURR_DIR}/eee-rich-regex.sh
 
+check_tools fzf bat rg
+
 # Switch between Ripgrep mode and fzf filtering mode (CTRL-T)
 rm -f /tmp/rg-fzf-{r,f}
 
@@ -21,23 +23,24 @@ TRANSFORMER='
 
   if ! [[ -r "$TEMP" ]] || [[ $rg_pat != $(cat "$TEMP") ]]; then
     echo "$rg_pat" > "$TEMP"
-    printf "reload:sleep 0.05; rg --column --line-number --no-heading --color=always --smart-case %q %q || true" "$rg_pat" ${QUERY_PATH} 
+    printf "reload:sleep 0.05; '"$RG"' --column --line-number --no-heading --color=always --smart-case %q %q || true" "$rg_pat" ${QUERY_PATH}
   fi
   echo "+search:$fzf_pat"
 '
 
-fzf --ansi --disabled --query "$INITIAL_QUERY" \
+$FZF --ansi --disabled --query "$INITIAL_QUERY" \
     --delimiter : --nth 3.. \
     --reverse \
     --exact \
     --cycle \
     --border \
     --with-shell 'bash -c' \
-    --bind "start,change:transform:$TRANSFORMER" \
+    --bind "start:transform:$TRANSFORMER" \
+    --bind "change:transform:$TRANSFORMER" \
     --color "hl:-1:underline,hl+:-1:underline:reverse,border:#A15ABD" \
     --delimiter : \
-    --preview 'bat --color=always {1} --highlight-line {2}' \
-    --preview-window 'up,70%,border-line,+{2}+3/3,~3' \
+    --preview "$BAT"' --color=always {1} --highlight-line {2}' \
+    --preview-window 'up,70%,+{2}+3/3,~3' \
     --bind 'ctrl-f:page-down,ctrl-b:page-up' |
     xargs -0 -I{} echo $(pwd)/{}
 


### PR DESCRIPTION
Tools may have different names in different OS.
For example, the bat command, in Ubuntu it is named as batcat.

check_tools is aimed to fix that.

Different script may need different tools. So the call of check_tools is placed in the script.