### PR TITLE
fix: add sleep delay in error of external terminal  execution

### DIFF
--- a/eee.el
+++ b/eee.el
@@ -62,7 +62,7 @@ The terminal emulator is specified in `ee-terminal-command'.
 See `ee-start-terminal-function' for the usage.
 "
   (let* ((options (ee-get-terminal-options))
-          (full-command (format "%s %s -e bash -c '%s'"
+          (full-command (format "%s %s -e bash -c '%s || sleep 1'"
                           ee-terminal-command
                           options
                           command))


### PR DESCRIPTION
In current situation of external termainl execution, if the command fails (due to command not found, variable not defined, etc), the screen just flashes, without knowing what happen.

Do a sleep if the command fails, to have a chance of knowing what happens.